### PR TITLE
ci: Add github action to apply version label to pre-release issues

### DIFF
--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -1,0 +1,15 @@
+name: Apply version label to issue
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  add-version-label-issue:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: gabrieldonadel/core-workflow-apply-version-label@v0.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Implement https://github.com/facebook/react-native/issues/32691

## Changelog

[Internal] [Added] - Add github action to apply version label to pre-release issues

## Test Plan


https://user-images.githubusercontent.com/11707729/150695215-e54932d6-974f-4296-beb2-41ae3702baf9.mov



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
