### PR TITLE
ci: Add build tests for RNTester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -589,10 +589,14 @@ jobs:
           command: cd template/android/ && ./gradlew assembleDebug
 
   # -------------------------
-  #    JOBS: Test Android RNTester with Hermes
+  #    JOBS: Test Android RNTester
   # -------------------------
-  test_android_rntester_hermes:
+  test_android_rntester:
     executor: reactnativeandroid
+    parameters:
+      use_hermes:
+          type: boolean
+          default: false
     steps:
       - checkout
       - run_yarn
@@ -601,26 +605,19 @@ jobs:
           name: Generate artifacts for Maven
           command: ./gradlew :ReactAndroid:installArchives
 
-      - run:
-          name: Build RNTester with Hermes
-          command: ./gradlew :packages:rn-tester:android:app:installHermesDebug
-
-  # -------------------------
-  #    JOBS: Test Android RNTester with JSC
-  # -------------------------
-  test_android_rntester_jsc:
-    executor: reactnativeandroid
-    steps:
-      - checkout
-      - run_yarn
-
-      - run:
-          name: Generate artifacts for Maven
-          command: ./gradlew :ReactAndroid:installArchives
-
-      - run:
-          name: Build RNTester with JSC
-          command: ./gradlew :packages:rn-tester:android:app:installJscDebug
+      - when:
+          condition: << parameters.use_hermes >>
+          steps:
+            - run:
+                name: Build RNTester with Hermes
+                command: ./gradlew :packages:rn-tester:android:app:assembleHermesDebug
+      - when:
+          condition:
+            not: << parameters.use_hermes >>
+          steps:
+            - run:
+                name: Build RNTester with JSC
+                command: ./gradlew :packages:rn-tester:android:app:assembleJscDebug
 
   # -------------------------
   #    JOBS: Test iOS Template
@@ -656,36 +653,24 @@ jobs:
               -sdk iphonesimulator
 
   # -------------------------
-  #    JOBS: Test iOS RNTester with Hermes
+  #    JOBS: Test iOS RNTester
   # -------------------------
-  test_ios_rntester_hermes:
+  test_ios_rntester:
     executor: reactnativeios
+    parameters:
+      use_hermes:
+          type: boolean
+          default: false
     steps:
       - checkout
       - run_yarn
 
-      - run:
-          name: Install CocoaPods dependencies
-          command: |
-            rm -rf packages/rn-tester/Pods
-            cd packages/rn-tester && USE_HERMES=1 bundle exec pod install
-
-      - run:
-          name: Build RNTester with Hermes
-          command: |
-            xcodebuild build \
-              -workspace RNTesterPods.xcworkspace \
-              -scheme RNTester \
-              -sdk iphonesimulator
-
-  # -------------------------
-  #    JOBS: Test iOS RNTester with JSC
-  # -------------------------
-  test_ios_rntester_jsc:
-    executor: reactnativeios
-    steps:
-      - checkout
-      - run_yarn
+      - when:
+          condition: << parameters.use_hermes >>
+          steps:
+            - run:
+                name: Set USE_HERMES=1
+                command: echo "export USE_HERMES=1" >> $BASH_ENV
 
       - run:
           name: Install CocoaPods dependencies
@@ -694,12 +679,13 @@ jobs:
             cd packages/rn-tester && bundle exec pod install
 
       - run:
-          name: Build RNTester with JSC
+          name: Build RNTester
           command: |
             xcodebuild build \
               -workspace RNTesterPods.xcworkspace \
               -scheme RNTester \
               -sdk iphonesimulator
+
   # -------------------------
   #    JOBS: Windows
   # -------------------------
@@ -964,17 +950,31 @@ workflows:
           filters:
             branches:
               ignore: gh-pages
-      - test_android_rntester_hermes:
+      - test_android_rntester:
+          name: test_android_rntester_hermes
+          use_hermes: true
           filters:
             branches:
               ignore: gh-pages
-      - test_android_rntester_jsc:
+      - test_android_rntester:
+          name: test_android_rntester_jsc
           filters:
             branches:
               ignore: gh-pages
       - test_ios_template:
           requires:
             - build_npm_package
+          filters:
+            branches:
+              ignore: gh-pages
+      - test_ios_rntester:
+          name: test_ios_rntester_hermes
+          use_hermes: true
+          filters:
+            branches:
+              ignore: gh-pages
+      - test_ios_rntester:
+          name: test_ios_rntester_jsc
           filters:
             branches:
               ignore: gh-pages


### PR DESCRIPTION
## Summary

Add 4 new jobs to CI in order to test RNTester builds on both Android and iOS using Hermes and JSC

Closes # 32676

## Changelog

[General] [Added] - Add build tests for RNTester to CI

## Test Plan

Make sure builds are working as expected and CI is green
